### PR TITLE
Improve deobfuscation output with new AST transformations

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,11 @@ function deobfuscate(source) {
             if(t.isLiteral(path.node.left)) {
                 path.replaceWith(t.binaryExpression(path.node.operator, path.node.right, path.node.left));
             }
-
+        },
+        VariableDeclaration(path) {
+            if (path.node.declarations.length > 1) {
+                path.replaceWithMultiple(path.node.declarations.map(d => t.variableDeclaration("var", [d])));
+            }
         }
     });
 

--- a/index.js
+++ b/index.js
@@ -20,29 +20,59 @@ function deobfuscate(source) {
     let stringArrName = undefined;
 
     traverse(ast, {
+        /*
+            Unroll sequence statements into individual statements.
+            Akamai's obfuscation litters this pattern all over their codebase.
+            e.g: b.innerHTML = "abcdefhijklmnopqrstuvxyz1234567890;+-.", b.style.fontSize = "90px", b.style.fontFamily = o[c]
+
+            This transformation will turn it into:
+            b.innerHTML = "abcdefhijklmnopqrstuvxyz1234567890;+-."
+            b.style.fontSize = "90px"
+            b.style.fontFamily = o[c]
+        */
         SequenceExpression(path) {
-            if (path.parent.type === 'ReturnStatement') {
+            if (path.parent && !t.isExpressionStatement(path.parent)) {
                 return;
             }
 
-            path.replaceWithMultiple(path.node.expressions);
-            path.skip();
-        }
-    });
+            path.parentPath.replaceWithMultiple(path.node.expressions.map(e => t.expressionStatement(e)));
+        },
+        /*
+            Akamai tends to flatten if statements into logical expressions.
+            This undoes that transformation.
 
-    traverse(ast, {
+            e.g: e && e.pageX && e.pageY ? (n = Math.floor(e.pageX), o = Math.floor(e.pageY)) : e && e.clientX && e.clientY && (n = Math.floor(e.clientX), o = Math.floor(e.clientY));
+
+            turns into:
+
+            if (e && e.pageX && e.pageY) {
+                n = Math.floor(e.pageX);
+                o = Math.floor(e.pageY);
+            } else {
+                if (e && e.clientX && e.clientY) {
+                    n = Math.floor(e.clientX);
+                    o = Math.floor(e.clientY);
+                }
+            }
+
+        */
         LogicalExpression(path) {
-            if (path.parent.type === 'ReturnStatement') {
+            if (!t.isExpressionStatement(path.parent)) {
                 return;
             }
-            if(path.node.right.type === 'SequenceExpression' || path.node.right.type === 'AssignmentExpression') {
-                // console.log("Called");
-                // console.log(generate(path.node, {}, source).code);
+            if(path.node.right.type === 'SequenceExpression' 
+                || path.node.right.type === 'AssignmentExpression' 
+                || path.node.right.type === 'CallExpression') {
                 path.parentPath.replaceWith(t.ifStatement(path.node.left, t.blockStatement([t.expressionStatement(path.node.right)]), null));
             }
         },
+        /*
+            Akamai uses void 0 to mean undefined sometimes.
+            They also use !0 as true and !1 as false.
+
+            This transforms them back into their respective meaning.
+        */
         UnaryExpression(path) {
-            // Replace void 0 with undefined
             if (path.node.operator === 'void' && path.node.argument.type === 'NumericLiteral') {
                 path.replaceWith(t.identifier("undefined"));
             }
@@ -99,14 +129,11 @@ function deobfuscate(source) {
     })
 
     traverse(ast, {
-        SequenceExpression(path) {
-            if (path.parent.type === 'ReturnStatement') {
-                return;
-            }
-
-            path.replaceWithMultiple(path.node.expressions);
-            path.skip();
-        },
+        /*
+            Make sure literals and undefined identifier is on the right in a binary expression.
+            undefined == a turns into a == undefined
+            0 == b turns into b == 0
+        */
         BinaryExpression(path) {
             if(path.node.left.type === 'Identifier') {
                 if(path.node.left.name === 'undefined') {
@@ -118,12 +145,61 @@ function deobfuscate(source) {
                 path.replaceWith(t.binaryExpression(path.node.operator, path.node.right, path.node.left));
             }
         },
+        /*
+            Akamai sometimes defines multiple variables with one var keyword.
+            This gives them their own declaration.
+
+            e.g:
+            var bm_url = bm_script.src, url_split = bm_url.split("/"), obfus_state_field;
+
+            turns into:
+            var bm_url = bm_script.src;
+            var url_split = bm_url.split("/");
+            var obfus_state_field;
+        */
         VariableDeclaration(path) {
             if (path.node.declarations.length > 1) {
                 path.replaceWithMultiple(path.node.declarations.map(d => t.variableDeclaration("var", [d])));
             }
+        },
+        ConditionalExpression(path) {
+            if (t.isAssignmentExpression(path.parent) || t.isReturnStatement(path.parent)) {
+                return;
+            }
+
+            if(!t.isExpressionStatement(path.parent)) {
+                return;
+            }
+
+            path.parentPath.replaceWith(t.ifStatement(path.node.test, t.blockStatement([t.expressionStatement(path.node.consequent)]), t.blockStatement([t.expressionStatement(path.node.alternate)])));
+            path.parentPath.skip();
         }
     });
+
+    traverse(ast, {
+        LogicalExpression(path) {
+            if (!t.isExpressionStatement(path.parent)) {
+                return;
+            }
+            if(path.node.right.type === 'SequenceExpression' 
+                || path.node.right.type === 'AssignmentExpression' 
+                || path.node.right.type === 'CallExpression') {
+                path.parentPath.replaceWith(t.ifStatement(path.node.left, t.blockStatement([t.expressionStatement(path.node.right)]), null));
+            }
+        }
+    });
+
+    traverse(ast, {
+        SequenceExpression(path) {
+            if (path.parent && !t.isExpressionStatement(path.parent)) {
+                return;
+            }
+
+            path.parentPath.replaceWithMultiple(path.node.expressions.map(e => t.expressionStatement(e)));
+        }
+    });
+
+    
 
     // Generate the new code given our modifications to the AST
     // and beautify it to recover any indentation that may have

--- a/index.js
+++ b/index.js
@@ -196,7 +196,20 @@ function deobfuscate(source) {
             }
 
             path.parentPath.replaceWithMultiple(path.node.expressions.map(e => t.expressionStatement(e)));
-        }
+        },
+        UnaryExpression(path) {
+            if (path.node.operator === 'void' && path.node.argument.type === 'NumericLiteral') {
+                path.replaceWith(t.identifier("undefined"));
+            }
+
+            if (path.node.operator === '!' && path.node.argument.type === 'NumericLiteral') {
+                if (path.node.argument.value === 0) {
+                    path.replaceWith(t.booleanLiteral(true));
+                } else {
+                    path.replaceWith(t.booleanLiteral(false));
+                }
+            }
+        },
     });
 
     

--- a/index.js
+++ b/index.js
@@ -43,8 +43,16 @@ function deobfuscate(source) {
         },
         UnaryExpression(path) {
             // Replace void 0 with undefined
-            if(path.node.operator === 'void' && path.node.argument.type === 'NumericLiteral') {
+            if (path.node.operator === 'void' && path.node.argument.type === 'NumericLiteral') {
                 path.replaceWith(t.identifier("undefined"));
+            }
+
+            if (path.node.operator === '!' && path.node.argument.type === 'NumericLiteral') {
+                if (path.node.argument.value === 0) {
+                    path.replaceWith(t.booleanLiteral(true));
+                } else {
+                    path.replaceWith(t.booleanLiteral(false));
+                }
             }
         },
         VariableDeclaration(path) {
@@ -98,6 +106,18 @@ function deobfuscate(source) {
 
             path.replaceWithMultiple(path.node.expressions);
             path.skip();
+        },
+        BinaryExpression(path) {
+            if(path.node.left.type === 'Identifier') {
+                if(path.node.left.name === 'undefined') {
+                    path.replaceWith(t.binaryExpression(path.node.operator, path.node.right, path.node.left));
+                }
+            }
+
+            if(t.isLiteral(path.node.left)) {
+                path.replaceWith(t.binaryExpression(path.node.operator, path.node.right, path.node.left));
+            }
+
         }
     });
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,24 @@ function deobfuscate(source) {
     let stringArrName = undefined;
 
     traverse(ast, {
+        SequenceExpression(path) {
+            if (path.parent.type === 'ReturnStatement') {
+                return;
+            }
+
+            path.replaceWithMultiple(path.node.expressions);
+            path.skip();
+        },
+        LogicalExpression(path) {
+            if (path.parent.type === 'ReturnStatement') {
+                return;
+            }
+            if(path.node.right.type === 'SequenceExpression' || path.node.right.type === 'AssignmentExpression') {
+                console.log("Called");
+                console.log(generate(path.node, {}, source).code);
+                path.parentPath.replaceWith(t.ifStatement(path.node.left, t.blockStatement([t.expressionStatement(path.node.right)]), null));
+            }
+        },
         VariableDeclaration(path) {
             // Find the variable that holds all the function
             // and property names by finding the first array


### PR DESCRIPTION
**Split variables with multiple declarations into their own declarations**
Before:
![image](https://user-images.githubusercontent.com/25884226/132632659-9c0a7df8-32b0-412c-acf5-d6a709cd7424.png)

After:
![image](https://user-images.githubusercontent.com/25884226/132632693-bb2c1254-e38b-452c-b133-4d55713266c6.png)

**Turn sequence expressions into multiple expressions:**
Before:
![image](https://user-images.githubusercontent.com/25884226/132632767-257bd65f-86e4-44fa-abee-21fb4f8fd476.png)

After:
![image](https://user-images.githubusercontent.com/25884226/132632827-4ea5a09b-3519-423a-bd36-ea80bdcbcd53.png)

**Change void 0, !0, !1 into their respective meanings:**
Before:
![image](https://user-images.githubusercontent.com/25884226/132633087-2c932ea6-3348-4d9a-844d-50b49ca2db41.png)

After:
![image](https://user-images.githubusercontent.com/25884226/132633126-9212c4b4-00a8-46d9-bfc4-632a10d0aef7.png)
